### PR TITLE
Hopefully improve compatibility of gen_assets.sh

### DIFF
--- a/sdlreversi/gen_assets.sh
+++ b/sdlreversi/gen_assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f assets.h assets.cpp assets_load.c assets_free.c assets_decl.c
 touch assets.h assets.cpp assets_load.c assets_free.c assets_decl.c


### PR DESCRIPTION
Adding `/usr/bin/env` should allow running scripts with non-standard bash paths!