### PR TITLE
[Minesweeper] Prevent lose on first move

### DIFF
--- a/sdlmine/logic.h
+++ b/sdlmine/logic.h
@@ -14,6 +14,7 @@ extern unsigned minefield_x, minefield_y, minefield_mines;
 extern char * minefield;
 extern char * minefield_visible;
 extern int mine_counter;
+extern char first_move;
 
 void regenerate_minefield(unsigned x, unsigned y, unsigned mines);
 int toggle_flag(int x, int y);


### PR DESCRIPTION
If first move is a mine, swap it with a random free cell.

# Motivation

![image](https://github.com/kspalaiologos/sdlgames/assets/50977029/078836c0-b3b7-4e72-82e3-7d2d40930656)
(this happened the very first time I tried this)